### PR TITLE
Reconnect to screen session automatically

### DIFF
--- a/roles/ubuntu.deploy/files/.profile
+++ b/roles/ubuntu.deploy/files/.profile
@@ -1,0 +1,8 @@
+# ~/.profile: executed by the command interpreter for login shells.
+# This file is not read by bash(1), if ~/.bash_profile or ~/.bash_login
+# exists.
+
+# Resume screen sessions automatically
+if [ -z "$STY" ]; then
+    exec screen -xRR
+fi

--- a/roles/ubuntu.deploy/tasks/main.yml
+++ b/roles/ubuntu.deploy/tasks/main.yml
@@ -56,6 +56,7 @@
     - deploy-openstack-ha.sh
     - deploy-openstack-ceph.sh
     - deploy-ubuntu-openstack.sh
+
 - name: copy rc files
   sudo: no
   copy: >-
@@ -64,3 +65,4 @@
     mode=0660
   with_items:
     - .screenrc
+    - .profile


### PR DESCRIPTION
Upon connecting to the deploy node, reconnect automatically to a
pre-existing screen session.  If it doesn't exist, launch one.